### PR TITLE
Removing the terms 'required' and 'optional'

### DIFF
--- a/artifacts/macos/macos.softwareupdate_v1.rst
+++ b/artifacts/macos/macos.softwareupdate_v1.rst
@@ -7,10 +7,10 @@ Description
 The macos:softwareupdate_test is used to check the status of automatic
 software updates on MacOSX.
 
-The required softwareupdate_object is used to access automatic
+The softwareupdate_object is used to access automatic
 software update information.
 
-The optional softwareupdate_state element makes it possible to make assertions
+The softwareupdate_state element makes it possible to make assertions
 about the state of automatic software updates.
 
 Technical Details


### PR DESCRIPTION
I missed these terms when we merged the branch on Friday. Removing them now.