### PR TITLE
Feature/op 2504 update community link info

### DIFF
--- a/about/about.rst
+++ b/about/about.rst
@@ -21,6 +21,4 @@ Key terms:
 - the various formats that can be generated from the defined benchmark content including recommendation prose and Artifacts
 
 **Benchmark Customization Community**
-- Join the Benchmark Customization Community below if you want to provide feedback or ask questions about tailoring or Artifact Expressions
-
-https://workbench.cisecurity.org/communities/148
+- SecureSuite members can join the `CIS Members : Benchmark Customization Discussions <https://workbench.cisecurity.org/communities/148>`_ Community on WorkBench. This community is a place to seek guidance, or share experience and information with other benchmark customization users.

--- a/about/about.rst
+++ b/about/about.rst
@@ -21,4 +21,4 @@ Key terms:
 - the various formats that can be generated from the defined benchmark content including recommendation prose and Artifacts
 
 **Benchmark Customization Community**
-- SecureSuite members can join the `CIS Members : Benchmark Customization Discussions <https://workbench.cisecurity.org/communities/148>`_ Community on WorkBench. This community is a place to seek guidance, or share experience and information with other benchmark customization users.
+- `CIS SecureSuite <https://www.cisecurity.org/cis-securesuite>`_ members can join the `CIS Members : Benchmark Customization Discussions <https://workbench.cisecurity.org/communities/148>`_ Community on WorkBench. This community is a place to seek guidance, or share experience and information with other benchmark customization users.

--- a/about/help.rst
+++ b/about/help.rst
@@ -4,8 +4,6 @@ Help
 Contact Us
 ----------
 
-Join the `CIS Members : Benchmark Customization Discussions Community on WorkBench
-<https://workbench.cisecurity.org/communities/148>`_.
+SecureSuite members can join the `CIS Members : Benchmark Customization Discussions <https://workbench.cisecurity.org/communities/148>`_ Community on WorkBench. This community is a place to seek guidance, or share experience and information with other benchmark customization users.
 
-This community is a place to seek guidance, share experience or information between users. If you
-need further assistance, follow the link to the `Support Portal <https://www.cisecurity.org/support>`_.
+If you need further assistance, follow the link to the `Support Portal <https://www.cisecurity.org/support>`_.

--- a/about/help.rst
+++ b/about/help.rst
@@ -6,4 +6,4 @@ Contact Us
 
 `CIS SecureSuite <https://www.cisecurity.org/cis-securesuite>`_ members can join the `CIS Members : Benchmark Customization Discussions <https://workbench.cisecurity.org/communities/148>`_ Community on WorkBench. This community is a place to seek guidance, or share experience and information with other benchmark customization users.
 
-If you need further assistance, follow the link to the `Support Portal <https://www.cisecurity.org/support>`_.
+For further assistance, please view our `Tailoring Benchmarks Quick Start Guide <https://cisecurity.atlassian.net/wiki/spaces/SCFKB/pages/2671870093/Quick+Start+Guide+Tailoring+Benchmarks>`_ or contact our `Support Team <https://cisecurity.atlassian.net/servicedesk/customer/portal/15/group/35/create/144>`_.

--- a/about/help.rst
+++ b/about/help.rst
@@ -4,6 +4,6 @@ Help
 Contact Us
 ----------
 
-SecureSuite members can join the `CIS Members : Benchmark Customization Discussions <https://workbench.cisecurity.org/communities/148>`_ Community on WorkBench. This community is a place to seek guidance, or share experience and information with other benchmark customization users.
+`CIS SecureSuite <https://www.cisecurity.org/cis-securesuite>`_ members can join the `CIS Members : Benchmark Customization Discussions <https://workbench.cisecurity.org/communities/148>`_ Community on WorkBench. This community is a place to seek guidance, or share experience and information with other benchmark customization users.
 
 If you need further assistance, follow the link to the `Support Portal <https://www.cisecurity.org/support>`_.


### PR DESCRIPTION
[OP-2504](https://cisecurity.atlassian.net/browse/OP-2504)

Changes to About and Help pages, to specify the Benchmark Customization Discussions community is for SecureSuite members only. 